### PR TITLE
leaderboard fixes

### DIFF
--- a/app/src/main/java/com/example/qrmon/LeaderboardAdapter.java
+++ b/app/src/main/java/com/example/qrmon/LeaderboardAdapter.java
@@ -79,6 +79,7 @@ public class LeaderboardAdapter extends ArrayAdapter<LeaderboardObject> {
         }
         catch (Exception e){
             e.getMessage();
+            return convertView;
         }
 
         codeNameTextView.setText(leaderboardObject.getName());


### PR DESCRIPTION
if you tapped on the screen before the data had finished loading after changing the leaderboard type, the app would crash. this is now fixed